### PR TITLE
Fix outdated radix sort tests

### DIFF
--- a/src/tritonsort/tests/mapreduce/common/sorting/RadixSortStrategyTests.cc
+++ b/src/tritonsort/tests/mapreduce/common/sorting/RadixSortStrategyTests.cc
@@ -11,26 +11,10 @@ void RadixSortStrategyTests::testUniformSize(
     strategy, numRecords, keyLength, valueLength, secondaryKeys);
 }
 
-void RadixSortStrategyTests::testVariableSize(
-  uint64_t numRecords, bool secondaryKeys) {
-
-  RadixSortStrategy strategy(secondaryKeys);
-
-  testVariableSizeRecords(strategy, numRecords, secondaryKeys);
-}
-
 void RadixSortStrategyTests::testNormal() {
   testUniformSize(5000, 10, 90, false);
 }
 
 void RadixSortStrategyTests::testSecondaryKeys() {
   testUniformSize(5000, 10, 90, true);
-}
-
-void RadixSortStrategyTests::testKeyPadding() {
-  testVariableSize(5000, false);
-}
-
-void RadixSortStrategyTests::testSecondaryKeysWithKeyPadding() {
-  testVariableSize(5000, true);
 }

--- a/src/tritonsort/tests/mapreduce/common/sorting/RadixSortStrategyTests.h
+++ b/src/tritonsort/tests/mapreduce/common/sorting/RadixSortStrategyTests.h
@@ -6,24 +6,18 @@
 class RadixSortStrategyTests : public SortStrategyTestSuite {
   CPPUNIT_TEST_SUITE( RadixSortStrategyTests );
   CPPUNIT_TEST( testNormal );
-  CPPUNIT_TEST( testKeyPadding );
   CPPUNIT_TEST( testSecondaryKeys );
-  CPPUNIT_TEST( testSecondaryKeysWithKeyPadding );
 
 
   CPPUNIT_TEST_SUITE_END();
 public:
   void testNormal();
-  void testKeyPadding();
-  void testSecondaryKeysWithKeyPadding();
   void testSecondaryKeys();
 
 private:
   void testUniformSize(
     uint64_t numRecords, uint64_t keyLength, uint64_t valueLength,
     bool secondaryKeys);
-
-  void testVariableSize(uint64_t numRecords, bool secondaryKeys);
 };
 
 #endif // THEMIS_RADIX_SORT_STRATEGY_TESTS_H


### PR DESCRIPTION
Remove radix sort tests that test for variably sized keys since this feature was found to be unstable, and quick sort is used to handle variably sized keys.
